### PR TITLE
recurring, allow for free scriptSrc as well

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -2959,11 +2959,11 @@
       "complianz.version": "([\\d.]+)\\;version:\\1"
     },
     "pricing": [
-      "onetime"
+      "recurring"
     ],
     "requires": "WordPress",
     "saas": true,
-    "scriptSrc": "wp-content/plugins/complianz-gdpr-premium",
+    "scriptSrc": "wp-content/plugins/complianz-gdpr",
     "website": "https://complianz.io"
   },
   "Concrete CMS": {


### PR DESCRIPTION
The current implemtation will only recognize complianz premium. I've made the match less specific, allowing free to get recognized as well. 

In addition, I noticed the pricing was set to one time, while it is recurring. 