### PR TITLE
Measure Next.js App Router separately

### DIFF
--- a/src/technologies/n.json
+++ b/src/technologies/n.json
@@ -667,6 +667,21 @@
     },
     "website": "https://nextjs.org"
   },
+  "Next.js App Router": {
+    "cats": [
+      12
+    ],
+    "description": "The Next.js App Router is a new paradigm for building applications using React's latest features.",
+    "icon": "Next.js.svg",
+    "implies": [
+      "Next.js"
+    ],
+    "js": {
+      "next.AppDir": "true"
+    },
+    "requires": "Next.js",
+    "website": "https://nextjs.org/docs/app"
+  },
   "NextAuth.js": {
     "cats": [
       69

--- a/src/technologies/n.json
+++ b/src/technologies/n.json
@@ -677,7 +677,7 @@
       "Next.js"
     ],
     "js": {
-      "next.AppDir": "true"
+      "next.appDir": "true"
     },
     "requires": "Next.js",
     "website": "https://nextjs.org/docs/app"


### PR DESCRIPTION
This allows the new Next.js App Router, which has performance improvements, to be measured separately.

@pmeenan is there anyway of testing this? It should be measured for https://nextjs.org/ but not for https://example.com (for example).

Ideally we'd store the version number as well, but think that the `js` object is a set of OR clauses so that would include Next.JS without AppRouter in that too so don't think that's possible.

FYI @timneutkens @kara @housseindjirdeh
