### PR TITLE
add new svelte 4+ detection method

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -6927,6 +6927,9 @@
     "description": "Svelte is a free and open-source front end compiler created by Rich Harris and maintained by the Svelte core team members.",
     "dom": "[class*='svelte-']",
     "icon": "Svelte.svg",
+    "js": {
+      "__svelte": ""
+    },
     "oss": true,
     "website": "https://svelte.dev"
   },


### PR DESCRIPTION
As of Svelte 4, there is a window.__svelte object that can be used to detect Svelte usage. It is a more reliable way of detecting Svelte because it doesn't rely on the usage of the scoped styles feature. This commit adds it to the list of detection methods.

Example site that previously wasn't detected and now is: https://decortwist.com/ 