### PR TITLE
Update detection for Performance Lab WordPress plugin

### DIFF
--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -1098,7 +1098,7 @@
     "description": "Performance plugin from the WordPress Performance Group, which is a collection of standalone performance modules.",
     "icon": "Performance Lab.svg",
     "meta": {
-      "generator": "^Performance Lab ?([\\d.]+)?\\;version:\\1"
+      "generator": "^(Performance Lab|performance-lab) ?([\\d.]+)?\\;version:\\2"
     },
     "requires": "WordPress",
     "website": "https://wordpress.org/plugins/performance-lab/"


### PR DESCRIPTION
In https://github.com/WordPress/performance/pull/1103 (specifically [here](https://github.com/WordPress/performance/pull/1103/files#diff-733209cd1718b5cb445345c12b0fc02666cf6aab6e597c59fef8a9c13b33f047R61)) the `meta[name="generator"]` tag of the Performance Lab plugin was changed to use another format, which will be rolled out with the 3.0.0 release on April 15.

In order to continue to correctly detect usage of the plugin, this PR updates the Wappalyzer detection, to support both the old and new format.