### PR TITLE
Fix invalid regex for Judge.me

### DIFF
--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -638,7 +638,7 @@
       "recurring"
     ],
     "saas": true,
-    "scriptSrc": ".*\\.judge\\.me",
+    "scriptSrc": "\\.judge\\.me",
     "website": "https://judge.me"
   },
   "JuicyAds": {

--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -638,7 +638,7 @@
       "recurring"
     ],
     "saas": true,
-    "scriptSrc": "*\\.judge\\.me",
+    "scriptSrc": ".*\\.judge\\.me",
     "website": "https://judge.me"
   },
   "JuicyAds": {


### PR DESCRIPTION
This fixes an invalid regex which is causing the following error:

```
SyntaxError: Invalid regular expression: /{0,250}\.judge\.me/i: Nothing to repeat
```

The regex was recently changed in #23. @rockeynebhwani - Does this look correct to you?