### PR TITLE
Classify more systems as CMS

### DIFF
--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -324,7 +324,8 @@
   },
   "Magento": {
     "cats": [
-      6
+      6,
+      1
     ],
     "cookies": {
       "X-Magento-Vary": "",

--- a/src/technologies/o.json
+++ b/src/technologies/o.json
@@ -959,7 +959,8 @@
   },
   "OpenCart": {
     "cats": [
-      6
+      6,
+      1
     ],
     "cookies": {
       "OCSESSID": ""

--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -2775,7 +2775,8 @@
   },
   "PrestaShop": {
     "cats": [
-      6
+      6,
+      1
     ],
     "cookies": {
       "PrestaShop": ""

--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -2533,7 +2533,8 @@
   },
   "Shopify": {
     "cats": [
-      6
+	  6,
+      1
     ],
     "cookies": {
       "_shopify_s": "",

--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -1025,7 +1025,8 @@
   },
   "Webflow": {
     "cats": [
-      51
+      51,
+      1
     ],
     "description": "Webflow is Software-as-a-Service (SaaS) for website building and hosting.",
     "dom": "html[data-wf-site]",


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->
Resolves \#1

Many systems used to manage website content are not currently classified as CMSs. Since we're now independent from the original Wappalyzer, we can and should change that. This pull fixes it for the first, glaringly obvious cases.

The test websites are:

* https://www.keessmit.nl/ - Magento
* https://www.lepantalon.fr/en/ - PrestaShop
* https://www.cxracing.com/ - OpenCart
* https://www.shopify.com/
* https://webflow.com/

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://www.keessmit.nl/
- https://www.lepantalon.fr/en/
- https://www.cxracing.com/
- https://www.shopify.com/
- https://webflow.com/
