### PR TITLE
Add detection for the WordPress Block Editor

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -2066,6 +2066,16 @@
     ],
     "website": "https://wordpress.org"
   },
+  "WordPress Block Editor": {
+    "cats": [
+      51
+    ],
+    "description": "Sites using the WordPress Block Editor, also known as Gutenberg.",
+    "html": "<div[^>]+class=[\"']wp-block-*",
+    "icon": "WordPress.svg",
+    "requires": "WordPress",
+    "website": "https://wordpress.org/gutenberg/"
+  },
   "WordPress Default": {
     "cats": [
       80
@@ -2080,11 +2090,12 @@
     "scriptSrc": "/wp-content/themes/default/",
     "website": "https://wordpress.org/themes/default"
   },
-  "WordPress Full Site Editing": {
+  "WordPress Site Editor": {
     "cats": [
       51
     ],
     "description": "Full Site Editing enables users to design and customize their entire WordPress website with a block-based editor.",
+    "excludes": "WordPress Block Editor",
     "html": "<div class=\"wp-site-blocks\">",
     "icon": "WordPress.svg",
     "requires": "WordPress",


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

This pull request does a few things:

- It adds support for measuring the use of the `WordPress Block Editor`
- It renames the [recently introduced](https://github.com/HTTPArchive/wappalyzer/pull/42) `WordPress Full Site Editing` to `WordPress Site Editor` for consistency.
- It _excludes_ detection of the `WordPress Block Editor` when the `WordPress Site Editor` is detected, to avoid doubling up and to allow measuring websites switching over from one to the other.

The test websites below show cases for both:

- ma.tt uses the Site Editor
- joost.blog currently uses the Block Editor
- marieke.com uses the Block Editor

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://ma.tt/
- https://joost.blog/
- https://marieke.com/
