### PR TITLE
Fix Shopify's Hydrogen framework detection

### DIFF
--- a/src/technologies/h.json
+++ b/src/technologies/h.json
@@ -1693,7 +1693,7 @@
     ],
     "description": "Hydrogen is a front-end web development framework used for building Shopify custom storefronts.",
     "headers": {
-      "powered-by": "^Hydrogen$"
+      "powered-by": "^Hydrogen$|^Shopify.+Hydrogen$"
     },
     "icon": "Hydrogen.svg",
     "implies": [


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

We noticed that Hydrogen sites haven't been properly detected [since around April](https://lookerstudio.google.com/u/0/reporting/55bc8fad-44c2-4280-aa0b-5f3f0cd3d2be/page/M6ZPC?params=%7B%22df44%22:%22include%25EE%2580%25800%25EE%2580%2580IN%25EE%2580%2580Shopify%25EE%2580%2580Next.js%25EE%2580%2580Nuxt.js%25EE%2580%2580Remix%25EE%2580%2580Remixd%25EE%2580%2580Hydrogen%22%7D) this year. I talked with the Hydrogen team and there are currently two possible values depending on its version: `Shopify, Oxygen, Hydrogen` or `Shopify, Oxygen, Shopify-Hydrogen`.

I adjusted the regex to account for both of them.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://baboontothemoon.com/
- https://atoms.com/
- https://speak.wallstreetenglish.com/
- https://www.stickabush.com/
