### PR TITLE
Make Hydrogen regex less strict

### DIFF
--- a/src/technologies/h.json
+++ b/src/technologies/h.json
@@ -1693,7 +1693,7 @@
     ],
     "description": "Hydrogen is a front-end web development framework used for building Shopify custom storefronts.",
     "headers": {
-      "powered-by": "^Hydrogen$|^Shopify.+Hydrogen$"
+      "powered-by": "^Hydrogen$|Shopify.+Hydrogen"
     },
     "icon": "Hydrogen.svg",
     "implies": [


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

This PR makes the regular expression for detecting Hydrogen a bit less strict. This builds on the query results that @tunetheweb did which identified more variants of the header.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://baboontothemoon.com/
- https://atoms.com/
- https://speak.wallstreetenglish.com/
- https://www.stickabush.com/
- https://dossier.co/
- https://homesick.com/
- https://vedora.no/
