### PR TITLE
Fix React Router detection and update Remix implies field

### DIFF
--- a/src/technologies/r.json
+++ b/src/technologies/r.json
@@ -633,9 +633,9 @@
     "icon": "React Router.svg",
     "implies": "React",
     "oss": true,
-    "scriptSrc": [
-      "(?:/react-router(@|/)([\\d.]+)(?:/[a-z]+)?)?/react-router(?:\\.min)?\\.js\\;version:\\2"
-    ],
+    "js": {
+      "__reactRouterVersion": ""
+    },
     "website": "https://reactrouter.com"
   },
   "Reactive": {
@@ -1337,7 +1337,8 @@
     "description": "Remix is a React framework used for server-side rendering (SSR).",
     "icon": "Remix.svg",
     "implies": [
-      "React"
+      "React",
+      "React Router"
     ],
     "js": {
       "__remixContext": ""


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

- Updates React Router detection to use `__reactRouterVersion`
- Updates Remix to imply React Router (since all Remix apps use React Router)

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://chatgpt.com/
- https://shopify.com/
- https://reactrouter.com/
