### PR TITLE
Add: detect Twenty Twenty-Four WordPress core theme

### DIFF
--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -3216,6 +3216,20 @@
     "scriptSrc": "/wp-content/themes/twentytwenty/",
     "website": "https://wordpress.org/themes/twentytwenty"
   },
+  "Twenty Twenty-Four": {
+    "cats": [
+      80
+    ],
+    "description": "Twenty Twenty-Four is the default WordPress theme for 2024.",
+    "dom": "link[href*='/wp-content/themes/twentytwentyfour/']",
+    "icon": "WordPress.svg",
+    "pricing": [
+      "freemium"
+    ],
+    "requires": "WordPress",
+    "scriptSrc": "/wp-content/themes/twentytwentyfour/",
+    "website": "https://wordpress.org/themes/twentytwentyfour"
+  },
   "Twenty Twenty-One": {
     "cats": [
       80


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->
Resolves \#1

Add: detect Twenty Twenty-Four WordPress core theme, similar to other detections.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://subsidized-herring-9bc361.instawp.xyz/
- https://zestful-alpaca-2544c2.instawp.xyz/
- https://dazzling-puma-f935a7.instawp.xyz/
