### PR TITLE
Add: detect Twenty Twenty-Five WordPress core theme

### DIFF
--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -3234,6 +3234,20 @@
     "scriptSrc": "/wp-content/themes/twentytwentyone/",
     "website": "https://wordpress.org/themes/twentytwentyone"
   },
+  "Twenty Twenty-Five": {
+    "cats": [
+      80
+    ],
+    "description": "Twenty Twenty-Five is the default WordPress theme for 2025.",
+    "dom": "link[href*='/wp-content/themes/twentytwentyfive/']",
+    "icon": "WordPress.svg",
+    "pricing": [
+      "freemium"
+    ],
+    "requires": "WordPress",
+    "scriptSrc": "/wp-content/themes/twentytwentyfive/",
+    "website": "https://wordpress.org/themes/twentytwentyfive"
+  },
   "Twenty Twenty-Three": {
     "cats": [
       80


### PR DESCRIPTION
Add: detect Twenty Twenty-Five WordPress core theme 

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://zealous-cat-b832e8.instawp.xyz/
- https://pretty-quail-c3beae.instawp.xyz/
- https://silent-ladybird-a201b1.instawp.xyz/
