### PR TITLE
Update Framer Sites

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -1682,6 +1682,7 @@
   },
   "Framer Sites": {
     "cats": [
+      1,
       51
     ],
     "description": "Framer is a no-code web design platform for designing and publishing responsive websites.",
@@ -1691,9 +1692,6 @@
     "icon": "Framer Sites.svg",
     "implies": "React",
     "js": {
-      "Framer": "",
-      "Framer.Animatable": "",
-      "Framer.version": "([\\d\\.]+)\\;version:\\1\\;confidence:0",
       "__framer_importFromPackage": ""
     },
     "meta": {


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->


I've updated the Framer Sites category:
- We're a CMS so adding category 1 -> https://www.framer.com/features/scale/
- Removed `Framer`, `Framer.Animatable` and `Framer.version`, because those aren't in the bundles of Framer sites that have been published within the last 2 years and might lead to false positives (e.g. some people might use 'framer-motion' and call it 'framer'. Motion is now an independent project that is not related to sites created by the Framer SaaS)

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://www.framer.com -> should still be detected as Framer site
- https://www.mollie.com -> should still be detected as Framer site
