### PR TITLE
Fix overly broad selectors for CivicTheme

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -1632,7 +1632,7 @@
     "cats": [
       66
     ],
-    "description": "CivicTheme is an open source, inclusive and component-based design system. It was created so governments and corporations can rapidly assemble modern, consistent and compliant digital experiences.",
+    "description": "CivicTheme is an open source, inclusive, and component-based design system. It was created so governments and corporations can rapidly assemble modern, consistent and compliant digital experiences.",
     "dom": [
       "img[class~='civictheme-image']",
       "img[class~='civic-image']",

--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -1634,9 +1634,9 @@
     ],
     "description": "CivicTheme is an open source, inclusive and component-based design system. It was created so governments and corporations can rapidly assemble modern, consistent and compliant digital experiences.",
     "dom": [
-      "img[class*='civictheme-image']",
-      "img[class*='civic-image']",
-      "img[class*='ct-image']"
+      "img[class~='civictheme-image']",
+      "img[class~='civic-image']",
+      "img[class~='ct-image']"
     ],
     "icon": "civictheme.png",
     "oss": true,


### PR DESCRIPTION
Selectors for CivicTheme were overly broad and resulting in numerous false matches. Specifically, img[class*='ct-image'] was matching <img class="product-image">. Classes were changed to spaced valued - img[class~='ct-image'] - rather than contains.

**Test websites**:

- https://amazon.com/ - this was incorrectly being flagged for CivicTheme due to class="product-image".
- https://www.dss.gov.au/
