### PR TITLE
Stop running upload on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ jobs:
   test:
     name: WebPageTest Test Cases
     runs-on: ubuntu-latest
+    if: |
+      github.repository == 'HTTPArchive/wappalyzer' &&
+      (github.event_name != 'pull_request_target' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -15,6 +15,8 @@ jobs:
   test:
     name: Test and upload to GCP
     runs-on: ubuntu-latest
+    # Only run on main repo on and PRs that match the main repo
+    if: ${{ github.repository == 'HTTPArchive/wappalyzer' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
The upload requires a Secret, which won't exist on forks. It then fails causing confusion.

So this PR restricts the upload to the `HTTPArchive/Wappalyzer` repo.