### PR TITLE
Better test GitHub Actions restrictions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,8 @@ jobs:
     name: WebPageTest Test Cases
     runs-on: ubuntu-latest
     if: |
-      github.repository == 'HTTPArchive/wappalyzer' &&
-      (github.event_name != 'pull_request_target' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+      ${{ github.repository == 'HTTPArchive/wappalyzer' ||
+          github.event.pull_request.base.repo.full_name == 'HTTPArchive/wappalyzer' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
I got this wrong in #179 and restricted the tests from running at all on forks. Fixing here.