### PR TITLE
Liferay: add cookie + HTML signals for response-first detection

### DIFF
--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -753,11 +753,19 @@
     "cats": [
       1
     ],
+    "cookies": {
+      "GUEST_LANGUAGE_ID": "",
+      "COOKIE_SUPPORT": "\\;confidence:50"
+    },
     "cpe": "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
     "description": "Liferay is an open-source company that provides free documentation and paid professional service to users of its software.",
     "headers": {
       "Liferay-Portal": "[a-z\\s]+([\\d.]+)\\;version:\\1"
     },
+    "html": [
+      "Liferay\\.(?:Util|Language|ThemeDisplay|AUI)",
+      "id=\"_com_liferay_"
+    ],
     "icon": "Liferay.svg",
     "implies": "Java",
     "js": {


### PR DESCRIPTION
Liferay matches only the `Liferay-Portal` response header and the `window.Liferay` JS global. Hardened / CDN-fronted installs strip the `Liferay-Portal` header, and response-first (non-headless) analysis can't observe `window.Liferay`, so Liferay goes undetected despite unmistakable static markers.

This adds unique static signals (keeping the existing header/JS matches and version capture):

- **html**: `Liferay\.(?:Util|Language|ThemeDisplay|AUI)` (Liferay client JS API namespaces) and `id="_com_liferay_` (portlet DOM id prefix).
- **cookies**: `GUEST_LANGUAGE_ID`; `COOKIE_SUPPORT` at `confidence:50` (generic name, not standalone).

---
**Test websites**:

- https://www.javeriana.edu.co/
- https://www.um.es/
- https://www.ehu.eus/

_Assisted by Claude Code._