### PR TITLE
Omni CMS: add HTML signals (dom-only misses response-first detection)

### DIFF
--- a/src/technologies/o.json
+++ b/src/technologies/o.json
@@ -489,6 +489,10 @@
     ],
     "description": "Omni CMS (formerly OU Campus) is a web content management system developed by Modern Campus. Modern Campus is a SaaS-based student lifecycle management software designed to manage continuing education and non-degree programs.",
     "dom": "a[href*='a.cms.omniupdate.com/11/']",
+    "html": [
+      "a\\.cms\\.omniupdate\\.com",
+      "omniupdate\\.com/XSL/Variables"
+    ],
     "icon": "Modern Campus.png",
     "pricing": [
       "poa"


### PR DESCRIPTION
Omni CMS (Modern Campus, formerly OU Campus) matches only via a `dom` selector (`a[href*='a.cms.omniupdate.com/11/']`). Response-first / non-headless consumers don't evaluate `dom`, so Omni CMS goes undetected even when the marker is present in the HTML.

This adds `html` patterns for the same signal (statically matchable):

- `a\.cms\.omniupdate\.com` — the Omni CMS edit / last-published link host.
- `omniupdate\.com/XSL/Variables` — the OmniUpdate `ouc` XSL namespace.

---
**Test websites**:

- https://www.stonybrook.edu/
- https://www.fau.edu/
- https://www.aamu.edu/
- https://www.wilkes.edu/

_Assisted by Claude Code._