### PR TITLE
Wagtail: add HTML signal (dom-only misses response-first detection)

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -508,6 +508,9 @@
         }
       }
     },
+    "html": [
+      "data-block-key=\"[a-z0-9]{5}\""
+    ],
     "icon": "Wagtail.svg",
     "implies": [
       "Django",


### PR DESCRIPTION
Wagtail matches only via `dom` selectors (`[data-block-key]` + media rendition paths). Response-first / non-headless consumers don't evaluate `dom`, so Wagtail goes undetected even when the StreamField markup is present in the HTML.

This adds an `html` pattern for the StreamField block key — the same signal as the existing `dom` `[data-block-key]` rule, but statically matchable:

- `data-block-key="[a-z0-9]{5}"`

Note: like the existing dom rule, this only appears on pages rendering StreamField blocks.

---
**Test websites**:

- https://wagtail.org/
- https://torchbox.com/
- https://www.mozilla.org/
- https://www.oxfam.org.uk/

_Assisted by Claude Code._