### PR TITLE
Fix jQuery version false positive from plugin URLs

### DIFF
--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -893,7 +893,7 @@
     "scriptSrc": [
       "jquery",
       "/jquery(?:-(\\d+\\.\\d+\\.\\d+))[/.-]\\;version:\\1",
-      "/(\\d+\\.\\d+\\.\\d+)/jquery[/.-][^u]\\;version:\\1"
+      "/(\\d+\\.\\d+\\.\\d+)/jquery(?:\\.slim)?(?:\\.min)?\\.js\\;version:\\1"
     ],
     "website": "https://jquery.com"
   },


### PR DESCRIPTION
The first versioned `scriptSrc` pattern for jQuery matches jQuery **plugin** URLs and extracts the *plugin's* version as the jQuery version.

### Problem

```
/(\d+\.\d+\.\d+)/jquery[/.-][^u]
```

The `[^u]` guard only excludes `jquery-ui`. Any other plugin whose filename starts with `jquery` still matches:

```
https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js
                                                    ^^^^^ extracted as jQuery 1.4.1
```

A site running jQuery 3.7.x is therefore reported as jQuery 1.4.1. Because this technology carries a CPE (`cpe:2.3:a:jquery:jquery`), the wrong version propagates into CVE matching downstream and produces false vulnerability findings — including CVE-2020-11023, which is in CISA KEV.

### Change

```
/(\d+\.\d+\.\d+)/jquery(?:\.slim)?(?:\.min)?\.js
```

Requires the filename to be jQuery core itself (`jquery.js`, `jquery.min.js`, `jquery.slim.js`, `jquery.slim.min.js`) rather than any file merely starting with `jquery`. The `[^u]` guard for `jquery-ui` is no longer needed because `jquery-ui.min.js` does not match.

| scriptSrc | before | after |
|---|---|---|
| `/3.7.1/jquery.min.js` | 3.7.1 | 3.7.1 |
| `/3.6.0/jquery.js` | 3.6.0 | 3.6.0 |
| `/3.6.0/jquery.slim.min.js` | 3.6.0 | 3.6.0 |
| `/jquery-cookie/1.4.1/jquery.cookie.min.js` | **1.4.1** | no version |
| `/jqueryui/1.13.2/jquery-ui.min.js` | **1.13.2** | no version |
| `/1.0.0/jquery.fancybox.min.js` | **1.0.0** | no version |

Plugin URLs still identify jQuery itself through the plain `"jquery"` pattern; only the incorrect version is dropped.

### Note on lookaheads

I deliberately avoided a negative lookahead here. These definitions are consumed by [wappalyzergo](https://github.com/projectdiscovery/wappalyzergo), a Go port whose regexp engine (RE2) does not support lookaheads — patterns using them silently fail to compile there. The enumerated-suffix form above behaves identically in both engines.

---

**Test websites**:

- https://gigazine.net/ (loads `ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js` — still detected as jQuery 1.12.4)
- https://www.asahibeer.co.jp/ (loads `ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js` — still detected as jQuery 3.2.1)
